### PR TITLE
Fix cache expiration

### DIFF
--- a/backend/Comfy.Repositories/Comfy.Repository.Cache.Redis/RedisCacheProvider.cs
+++ b/backend/Comfy.Repositories/Comfy.Repository.Cache.Redis/RedisCacheProvider.cs
@@ -111,7 +111,7 @@ namespace Comfy.Cache.Redis
 
             await _cache.SetAsync(summary, Encoding.UTF8.GetBytes(summaryAsJson), new DistributedCacheEntryOptions
             {
-                SlidingExpiration = DateTime.Now.AddHours(1).TimeOfDay
+                SlidingExpiration = TimeSpan.FromHours(1)
             });
         }
 


### PR DESCRIPTION
## Summary
- bugfix: use `TimeSpan.FromHours(1)` for cache sliding expiration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b48f9188883258f9c8f55c70b73fc